### PR TITLE
Fix caching issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,8 +174,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.100.3",
-    "@raycast/utils": "^2.2.0",
-    "use-immer": "^0.11.0"
+    "@raycast/utils": "^2.2.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^1.0.11",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -27,9 +27,8 @@ export const getUserSelectedLanguages = async () => {
       selectedLanguages as unknown as string,
     ) as Language[];
     userSelectedLanguages = selectedLanguagesParsed;
-    return userSelectedLanguages;
   }
 
-  const languages: Language[] = [primaryLanguage];
+  const languages: Language[] = [...userSelectedLanguages, primaryLanguage];
   return languages;
 };

--- a/src/preferences/LanguageManager/LanguageManager.tsx
+++ b/src/preferences/LanguageManager/LanguageManager.tsx
@@ -86,7 +86,10 @@ export const LanguagesManagerList = () => {
     setSelectedLanguages((draft) => {
       draft.push(language);
     });
-    const payload = [...selectedLanguages, language];
+    const selectedLanguagesWithoutPrimary = selectedLanguages.filter(
+      (lang) => lang.value !== preference.primaryLanguage
+    );
+    const payload = [...selectedLanguagesWithoutPrimary, language];
     LocalStorage.setItem("SelectedLanguages", JSON.stringify(payload));
     showToast(Toast.Style.Success, "Language set was saved!");
   };
@@ -103,7 +106,10 @@ export const LanguagesManagerList = () => {
     const updatedLanguages = selectedLanguages.filter(
       (lang) => lang.value !== language.value,
     );
-    LocalStorage.setItem("SelectedLanguages", JSON.stringify(updatedLanguages));
+    const updatedLanguagesWithoutPrimary = updatedLanguages.filter(
+      (lang) => lang.value !== preference.primaryLanguage
+    );
+    LocalStorage.setItem("SelectedLanguages", JSON.stringify(updatedLanguagesWithoutPrimary));
   };
 
   useEffect(() => {

--- a/src/preferences/LanguageManager/LanguageManager.tsx
+++ b/src/preferences/LanguageManager/LanguageManager.tsx
@@ -8,8 +8,7 @@ import {
   showToast,
   Toast,
 } from "@raycast/api";
-import { useEffect } from "react";
-import { useImmer } from "use-immer";
+import { useEffect, useState } from "react";
 import supportedLanguages from "../../data/supportedLanguages";
 import { usePreferences } from "../../hooks";
 import { Language } from "../../types";
@@ -53,7 +52,7 @@ export function LanguagesManagerItem({
 
 export const LanguagesManagerList = () => {
   const preference = usePreferences();
-  const [selectedLanguages, setSelectedLanguages] = useImmer<Language[]>([]);
+  const [selectedLanguages, setSelectedLanguages] = useState<Language[]>([]);
 
   const getSelectedLanguages = async () => {
     const selectedLanguages = await LocalStorage.getItem("SelectedLanguages");
@@ -72,20 +71,14 @@ export const LanguagesManagerList = () => {
         selectedLanguages as unknown as string,
       ) as Language[];
 
-      setSelectedLanguages((draft) => {
-        draft.push(...data, primaryLanguage);
-      });
+      setSelectedLanguages([...data, primaryLanguage]);
     } else {
-      setSelectedLanguages((draft) => {
-        draft.push(primaryLanguage);
-      });
+      setSelectedLanguages([primaryLanguage]);
     }
   };
 
   const selectLanguage = (language: Language) => {
-    setSelectedLanguages((draft) => {
-      draft.push(language);
-    });
+    setSelectedLanguages((prev) => [...prev, language]);
     const selectedLanguagesWithoutPrimary = selectedLanguages.filter(
       (lang) => lang.value !== preference.primaryLanguage
     );
@@ -95,14 +88,9 @@ export const LanguagesManagerList = () => {
   };
 
   const unselectLanguage = (language: Language) => {
-    setSelectedLanguages((draft) => {
-      const deleteIndex = draft.findIndex(
-        (lang) => lang.value === language.value,
-      );
-      if (deleteIndex !== -1) {
-        draft.splice(deleteIndex, 1);
-      }
-    });
+    setSelectedLanguages((prev) =>
+      prev.filter((lang) => lang.value !== language.value)
+    );
     const updatedLanguages = selectedLanguages.filter(
       (lang) => lang.value !== language.value,
     );


### PR DESCRIPTION
Every time `getSelectedLanguages` runs (every `LanguageManager` render), it appends `primaryLanguage` to the cached languages array. So localstorage ends up like `['en-US', 'en-US', 'en-US', 'fr-FR']`. It's exacerbated in dev mode since strict mode is enabled which makes renders run twice.

Fix is to never cache primary language and make state updates idempotent.

This doesn't properly fix multilingual OCR as described in https://github.com/neo773/ScreenOCR/issues/5#issue-3820801313, but it does for some cases. (eg. English primary with Chinese selected)